### PR TITLE
modify boolean value parse

### DIFF
--- a/doclet/src/main/java/com/iggroup/oss/restdoclet/doclet/type/builder/RequestParameterBuilder.java
+++ b/doclet/src/main/java/com/iggroup/oss/restdoclet/doclet/type/builder/RequestParameterBuilder.java
@@ -73,7 +73,7 @@ public class RequestParameterBuilder extends BaseTypeBuilder {
       final AnnotationValue value =
          elementValue(param, RequestParam.class, "required");
       if (value != null) {
-         type.setRequired(Boolean.getBoolean(value.value().toString().trim()));
+         type.setRequired(Boolean.parseBoolean(value.value().toString().trim()));
       }
 
    }


### PR DESCRIPTION
when the value is "true",the Boolean.getBoolean() method return false, so change getBoolean() method to parseBoolean() method.

When I define @requestParam(value="sample",requried=true,defaultValue="0") String sample in a method,the value of the "smaple" required is false in the the restdoc xml file.